### PR TITLE
订单管理部分：apifox上已有的接口对应的代码已经写完

### DIFF
--- a/src/main/java/cn/edu/xidian/tafei_mall/controller/OrderController.java
+++ b/src/main/java/cn/edu/xidian/tafei_mall/controller/OrderController.java
@@ -1,10 +1,16 @@
 package cn.edu.xidian.tafei_mall.controller;
 
 
-import cn.edu.xidian.tafei_mall.service.OrderItemService;
+import cn.edu.xidian.tafei_mall.model.entity.User;
+import cn.edu.xidian.tafei_mall.model.vo.OrderCreateVO;
+import cn.edu.xidian.tafei_mall.model.vo.Response.Order.IdResponse;
+import cn.edu.xidian.tafei_mall.model.vo.Response.Order.MessageResponse;
+import cn.edu.xidian.tafei_mall.model.vo.Response.Order.getOrderResponse;
 import cn.edu.xidian.tafei_mall.service.OrderService;
+import cn.edu.xidian.tafei_mall.service.UserService;
 import io.swagger.annotations.ApiKeyAuthDefinition;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -15,29 +21,82 @@ import java.net.URI;
 @RestController
 @RequestMapping("/api/orders")
 public class OrderController {
-
     @Autowired
     private OrderService orderService;
-
     @Autowired
-    private OrderItemService orderItemService;
-
-    @GetMapping("/")
-    public ResponseEntity<?> searchOrder() {
-        return ResponseEntity.ok("");
+    private UserService userService;
+    /**
+     * 获取订单详情(用户)
+     * @param orderId 订单ID(不填就是查询当前用户所有订单)
+     * @param sessionId Session ID
+     * @return 订单详情
+     */
+    @GetMapping("/search")
+    public ResponseEntity<?> searchOrder(@RequestHeader("Session-Id") String sessionId,
+                                         @RequestParam(required = false, defaultValue = "-1") String orderId) {
+        try{
+            if (sessionId == null) {
+                return new ResponseEntity<>(new MessageResponse("未登录"), HttpStatus.UNAUTHORIZED);
+            }
+            User user = userService.getUserInfo(sessionId);
+            if (user == null) {
+                return new ResponseEntity<>(new MessageResponse("用户不存在"), HttpStatus.UNAUTHORIZED);
+            }
+            if (orderId.equals("-1")) {
+                getOrderResponse orders = orderService.getOrderByCustomer(user.getUserId());
+                return new ResponseEntity<>(orders, HttpStatus.OK);
+            } else {
+                getOrderResponse orders = orderService.getOrderByCustomer(orderId, user.getUserId());
+                return new ResponseEntity<>(orders, HttpStatus.OK);
+            }
+        } catch (Exception e) {
+            return new ResponseEntity<>(new MessageResponse(e.getMessage()), HttpStatus.BAD_REQUEST);
+        }
     }
-
+    /**
+     * 创建订单
+     * @param cartId 购物车ID
+     * @param orderCreateVO 地址ID
+     * @return 订单ID
+     */
     @PostMapping("/{cartId}")
-    public ResponseEntity<?> createOrder(@PathVariable String cartId) {
-        String orderId = "";
-
-        return ResponseEntity.created(URI.create(""))
-                .body(orderId);
+    public ResponseEntity<?> createOrder(@RequestHeader("Session-Id") String sessionId, @PathVariable String cartId, @RequestBody OrderCreateVO orderCreateVO) {
+        try{
+            if (sessionId == null) {
+                return new ResponseEntity<>(new MessageResponse("未登录"), HttpStatus.UNAUTHORIZED);
+            }
+            User user = userService.getUserInfo(sessionId);
+            if (user == null) {
+                return new ResponseEntity<>(new MessageResponse("用户不存在"), HttpStatus.UNAUTHORIZED);
+            }
+            String orderId = orderService.createOrder(cartId, orderCreateVO, user.getUserId());
+            return ResponseEntity.created(URI.create("Order")).body(orderId);
+        } catch (Exception e) {
+            return new ResponseEntity<>(new MessageResponse(e.getMessage()), HttpStatus.BAD_REQUEST);
+        }
     }
-
+    /**
+     * 取消订单
+     * @param orderId 订单ID
+     * @return 是否成功
+     */
     @DeleteMapping("/{orderId}")
-    public ResponseEntity<?> cancelOrder(@PathVariable String orderId) {
-        orderService.cancelOrder(orderId);
-        return ResponseEntity.noContent().build();
+    public ResponseEntity<?> cancelOrder(@RequestHeader("Session-Id") String sessionId, @PathVariable String orderId) {
+        try{
+            if (sessionId == null) {
+                return new ResponseEntity<>(new MessageResponse("未登录"), HttpStatus.UNAUTHORIZED);
+            }
+            User user = userService.getUserInfo(sessionId);
+            if (user == null) {
+                return new ResponseEntity<>(new MessageResponse("用户不存在"), HttpStatus.UNAUTHORIZED);
+            }
+            boolean flag = orderService.cancelOrder(orderId, user.getUserId());
+            if (!flag) {
+                return new ResponseEntity<>(new MessageResponse("取消失败"), HttpStatus.BAD_REQUEST);
+            }
+            return ResponseEntity.ok().body(orderId);
+        } catch (Exception e) {
+            return new ResponseEntity<>(new IdResponse(orderId), HttpStatus.OK);
+        }
     }
 }

--- a/src/main/java/cn/edu/xidian/tafei_mall/controller/SellerController.java
+++ b/src/main/java/cn/edu/xidian/tafei_mall/controller/SellerController.java
@@ -1,9 +1,10 @@
 package cn.edu.xidian.tafei_mall.controller;
 
 
-import cn.edu.xidian.tafei_mall.model.entity.Product;
 import cn.edu.xidian.tafei_mall.model.entity.User;
 import cn.edu.xidian.tafei_mall.model.vo.*;
+import cn.edu.xidian.tafei_mall.model.vo.Response.Order.MessageResponse;
+import cn.edu.xidian.tafei_mall.model.vo.Response.Order.getOrderResponse;
 import cn.edu.xidian.tafei_mall.model.vo.Response.Seller.addProductResponse;
 import cn.edu.xidian.tafei_mall.model.vo.Response.Seller.getProductResponse;
 import cn.edu.xidian.tafei_mall.service.ProductService;
@@ -11,7 +12,7 @@ import cn.edu.xidian.tafei_mall.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.*;
 import org.springframework.web.bind.annotation.*;
-
+import cn.edu.xidian.tafei_mall.service.OrderService;
 import java.net.URI;
 import java.util.Map;
 
@@ -37,6 +38,9 @@ public class SellerController {
 
     @Autowired
     private ProductService productService;
+
+    @Autowired
+    private OrderService orderService;
 
     @PostMapping("/products")
     public ResponseEntity<?> addProduct(@RequestBody ProductVO productVO, @RequestHeader("Session-Id") String sessionId) {
@@ -104,8 +108,19 @@ public class SellerController {
     }
 
     @GetMapping("/orders")
-    public ResponseEntity<?> getOrders() {
-        // Implement get orders logic
-        return ResponseEntity.ok("获取成功");
+    public ResponseEntity<?> getOrders(@RequestHeader("Session-Id") String sessionId) {
+        try{
+            if (sessionId == null) {
+                return new ResponseEntity<>(new MessageResponse("未登录"), HttpStatus.UNAUTHORIZED);
+            }
+            User user = userService.getUserInfo(sessionId);
+            if (user == null) {
+                return new ResponseEntity<>(new MessageResponse("用户不存在"), HttpStatus.UNAUTHORIZED);
+            }
+            getOrderResponse response = orderService.getOrderBySeller(user.getUserId());
+            return ResponseEntity.ok().body(response);
+        } catch (Exception e) {
+            return new ResponseEntity<>(new MessageResponse(e.getMessage()), HttpStatus.BAD_REQUEST);
+        }
     }
 }

--- a/src/main/java/cn/edu/xidian/tafei_mall/model/vo/OrderCreateVO.java
+++ b/src/main/java/cn/edu/xidian/tafei_mall/model/vo/OrderCreateVO.java
@@ -1,0 +1,9 @@
+package cn.edu.xidian.tafei_mall.model.vo;
+
+import lombok.Data;
+
+@Data
+public class OrderCreateVO {
+    private String sellerId;
+    private String shippingAddressId;
+}

--- a/src/main/java/cn/edu/xidian/tafei_mall/model/vo/Response/Order/IdResponse.java
+++ b/src/main/java/cn/edu/xidian/tafei_mall/model/vo/Response/Order/IdResponse.java
@@ -1,0 +1,14 @@
+package cn.edu.xidian.tafei_mall.model.vo.Response.Order;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Getter;
+
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class IdResponse {
+    private final String orderId;
+
+    public IdResponse(String orderId) {
+        this.orderId = orderId;
+    }
+}

--- a/src/main/java/cn/edu/xidian/tafei_mall/model/vo/Response/Order/MessageResponse.java
+++ b/src/main/java/cn/edu/xidian/tafei_mall/model/vo/Response/Order/MessageResponse.java
@@ -1,0 +1,14 @@
+package cn.edu.xidian.tafei_mall.model.vo.Response.Order;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Getter;
+
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class MessageResponse {
+    private final String message;
+
+    public MessageResponse(String message) {
+        this.message = message;
+    }
+}

--- a/src/main/java/cn/edu/xidian/tafei_mall/model/vo/Response/Order/OrderDetailResponse.java
+++ b/src/main/java/cn/edu/xidian/tafei_mall/model/vo/Response/Order/OrderDetailResponse.java
@@ -1,0 +1,18 @@
+package cn.edu.xidian.tafei_mall.model.vo.Response.Order;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Getter;
+
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class OrderDetailResponse {
+    private final String orderId;
+    private final String status;
+    private final getOrderItemResponse items;
+
+    public OrderDetailResponse(String orderId, String status, getOrderItemResponse items) {
+        this.orderId = orderId;
+        this.status = status;
+        this.items = items;
+    }
+}

--- a/src/main/java/cn/edu/xidian/tafei_mall/model/vo/Response/Order/OrderItemResponse.java
+++ b/src/main/java/cn/edu/xidian/tafei_mall/model/vo/Response/Order/OrderItemResponse.java
@@ -1,0 +1,22 @@
+package cn.edu.xidian.tafei_mall.model.vo.Response.Order;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class OrderItemResponse {
+    private final String productId;
+    private final String productName;
+    private final Integer quantity;
+    private final BigDecimal price;
+
+    public OrderItemResponse(String productId, String productName, Integer quantity, BigDecimal price) {
+        this.productId = productId;
+        this.productName = productName;
+        this.quantity = quantity;
+        this.price = price;
+    }
+}

--- a/src/main/java/cn/edu/xidian/tafei_mall/model/vo/Response/Order/getOrderItemResponse.java
+++ b/src/main/java/cn/edu/xidian/tafei_mall/model/vo/Response/Order/getOrderItemResponse.java
@@ -1,0 +1,16 @@
+package cn.edu.xidian.tafei_mall.model.vo.Response.Order;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class getOrderItemResponse {
+    private final List<OrderItemResponse> items;
+
+    public getOrderItemResponse(List<OrderItemResponse> items) {
+        this.items = items;
+    }
+}

--- a/src/main/java/cn/edu/xidian/tafei_mall/model/vo/Response/Order/getOrderResponse.java
+++ b/src/main/java/cn/edu/xidian/tafei_mall/model/vo/Response/Order/getOrderResponse.java
@@ -1,0 +1,16 @@
+package cn.edu.xidian.tafei_mall.model.vo.Response.Order;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class getOrderResponse {
+    private final List<OrderDetailResponse> orders;
+
+    public getOrderResponse(List<OrderDetailResponse> orders) {
+        this.orders = orders;
+    }
+}

--- a/src/main/java/cn/edu/xidian/tafei_mall/service/OrderItemService.java
+++ b/src/main/java/cn/edu/xidian/tafei_mall/service/OrderItemService.java
@@ -3,6 +3,8 @@ package cn.edu.xidian.tafei_mall.service;
 import cn.edu.xidian.tafei_mall.model.entity.OrderItem;
 import com.baomidou.mybatisplus.extension.service.IService;
 
+import java.util.List;
+
 /**
  * <p>
  * 订单项表 服务类
@@ -12,5 +14,8 @@ import com.baomidou.mybatisplus.extension.service.IService;
  * @since 2025-03-17
  */
 public interface OrderItemService extends IService<OrderItem> {
-
+    // Server层中，同层调用，不需要暴露给上层
+    OrderItem getOrderItemById(String orderItemId);
+    List<OrderItem> getOrderItemByOrderId(String orderId);
+    String addOrderItem(OrderItem orderItem);
 }

--- a/src/main/java/cn/edu/xidian/tafei_mall/service/OrderService.java
+++ b/src/main/java/cn/edu/xidian/tafei_mall/service/OrderService.java
@@ -1,6 +1,8 @@
 package cn.edu.xidian.tafei_mall.service;
 
 import cn.edu.xidian.tafei_mall.model.entity.Order;
+import cn.edu.xidian.tafei_mall.model.vo.OrderCreateVO;
+import cn.edu.xidian.tafei_mall.model.vo.Response.Order.getOrderResponse;
 import com.baomidou.mybatisplus.extension.service.IService;
 
 /**
@@ -12,6 +14,13 @@ import com.baomidou.mybatisplus.extension.service.IService;
  * @since 2025-03-17
  */
 public interface OrderService extends IService<Order> {
-
-    void cancelOrder(String orderId);
+    // Server层中，同层调用，不需要暴露给上层
+    Order getOrderById(String orderId);
+    // 买家
+    getOrderResponse getOrderByCustomer(String userId);
+    getOrderResponse getOrderByCustomer(String OrderId, String userId);
+    String createOrder(String cartId, OrderCreateVO orderCreateVO, String userId);
+    boolean cancelOrder(String orderId, String userId);
+    // 卖家
+    getOrderResponse getOrderBySeller(String userId);
 }

--- a/src/main/java/cn/edu/xidian/tafei_mall/service/impl/OrderItemServiceImpl.java
+++ b/src/main/java/cn/edu/xidian/tafei_mall/service/impl/OrderItemServiceImpl.java
@@ -3,8 +3,12 @@ package cn.edu.xidian.tafei_mall.service.impl;
 import cn.edu.xidian.tafei_mall.model.entity.OrderItem;
 import cn.edu.xidian.tafei_mall.mapper.OrderItemMapper;
 import cn.edu.xidian.tafei_mall.service.OrderItemService;
+import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
 import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 /**
  * <p>
@@ -16,5 +20,22 @@ import org.springframework.stereotype.Service;
  */
 @Service
 public class OrderItemServiceImpl extends ServiceImpl<OrderItemMapper, OrderItem> implements OrderItemService {
+    @Autowired
+    private OrderItemMapper orderItemMapper;
 
+    @Override
+    public OrderItem getOrderItemById(String orderItemId){
+        return orderItemMapper.selectById(orderItemId);
+    }
+
+    @Override
+    public List<OrderItem> getOrderItemByOrderId(String orderId){
+        return orderItemMapper.selectList(new QueryWrapper<OrderItem>().eq("order_id", orderId));
+    }
+
+    @Override
+    public String addOrderItem(OrderItem orderItem){
+        orderItemMapper.insert(orderItem);
+        return orderItem.getOrderItemId();
+    }
 }

--- a/src/main/java/cn/edu/xidian/tafei_mall/service/impl/OrderServiceImpl.java
+++ b/src/main/java/cn/edu/xidian/tafei_mall/service/impl/OrderServiceImpl.java
@@ -1,12 +1,26 @@
 package cn.edu.xidian.tafei_mall.service.impl;
 
-import cn.edu.xidian.tafei_mall.model.entity.Order;
+import cn.edu.xidian.tafei_mall.mapper.CartItemMapper;
+import cn.edu.xidian.tafei_mall.mapper.CartMapper;
+import cn.edu.xidian.tafei_mall.model.entity.*;
 import cn.edu.xidian.tafei_mall.mapper.OrderMapper;
-import cn.edu.xidian.tafei_mall.service.OrderService;
+import cn.edu.xidian.tafei_mall.model.vo.OrderCreateVO;
+import cn.edu.xidian.tafei_mall.model.vo.Response.Order.OrderDetailResponse;
+import cn.edu.xidian.tafei_mall.model.vo.Response.Order.OrderItemResponse;
+import cn.edu.xidian.tafei_mall.model.vo.Response.Order.getOrderItemResponse;
+import cn.edu.xidian.tafei_mall.model.vo.Response.Order.getOrderResponse;
+import cn.edu.xidian.tafei_mall.service.*;
+import cn.hutool.core.bean.BeanUtil;
+import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
 import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.*;
 
 /**
  * <p>
@@ -18,29 +32,190 @@ import java.time.LocalDateTime;
  */
 @Service
 public class OrderServiceImpl extends ServiceImpl<OrderMapper, Order> implements OrderService {
+    @Autowired
+    private OrderMapper orderMapper;
+    @Autowired
+    private OrderItemService orderItemService;
+    @Autowired
+    private ProductService productService;
+    /* 由于Service层的Cart不完整，暂时用Mapper层的方法代替
+    @Autowired
+    private CartService cartService;
+    @Autowired
+    private CartItemService cartItemService;
+     */
+    @Autowired
+    private CartMapper cartMapper;
+    @Autowired
+    private CartItemMapper cartItemMapper;
 
+    /**
+     * 获取订单(内部使用)
+     * @param orderId 订单ID
+     * @return 订单项列表
+     */
     @Override
-    public void cancelOrder(String orderId) {
-        // 查询订单
-        Order order = getById(orderId);
+    public Order getOrderById(String orderId){
+        return orderMapper.selectById(orderId);
+    }
+
+    /**
+     * 获取订单详情(买家)
+     * @param userId 用户ID
+     * @return 订单详情列表
+     */
+    @Override
+    public getOrderResponse getOrderByCustomer(String userId){
+        List <Order> orders = orderMapper.selectList(new QueryWrapper<Order>().eq("user_id", userId));
+        if (orders.isEmpty()) {
+            return null;
+        }
+        // 获取订单项
+        List<OrderDetailResponse> orderDetailResponses = new ArrayList<>();
+        for (Order order : orders) {
+            orderDetailResponses.add(OrderDetailGenerator(order));
+        }
+        return new getOrderResponse(orderDetailResponses);
+    }
+
+    /**
+     * 获取订单详情(买家)
+     * @param OrderId 订单ID
+     * @param userId 用户ID
+     * @return 订单详情列表
+     */
+    @Override
+    public getOrderResponse getOrderByCustomer(String OrderId, String userId) {
+        Order order = orderMapper.selectById(OrderId);
+        if (order == null) {
+            return null;
+        }
+        if (!order.getUserId().equals(userId)) {
+            throw new IllegalArgumentException("Order does not belong to current user");
+        }
+        // 获取订单项
+        List<OrderDetailResponse> orderDetailResponses = new ArrayList<>();
+        orderDetailResponses.add(OrderDetailGenerator(order));
+        return new getOrderResponse(orderDetailResponses);
+    }
+
+    /**
+     * 创建订单
+     * @param cartId 购物车ID
+     * @param orderCreateVO 地址ID
+     * @param userId 用户ID
+     * @return 订单ID
+     */
+    @Override
+    public String createOrder(String cartId, OrderCreateVO orderCreateVO, String userId) {
+        // Cart cart = cartService.getCartById(cartId);
+        Cart cart = cartMapper.selectById(cartId);
+        if (cart == null) {
+            throw new IllegalArgumentException("Invalid cart ID");
+        }
+        if (!cart.getUserId().equals(userId)) {
+            throw new IllegalArgumentException("Cart does not belong to current user");
+        }
+        // 获取购物车
+        // List<CartItem> cartItems = cartItemService.getCartItemsByCartId(cartId);
+        List<CartItem> cartItems = cartItemMapper.selectList(new QueryWrapper<CartItem>().eq("cart_id", cartId));
+        if (cartItems.isEmpty()) {
+            throw new IllegalArgumentException("Cart is empty");
+        }
+
+        // 创建订单
+        Order order = BeanUtil.toBean(orderCreateVO, Order.class);
+        order.setUserId(userId);
+        order.setStatus("pending"); // 已提交未付款
+        orderMapper.insert(order);
+        String orderId = order.getOrderId();
+
+        // 创建订单项
+        BigDecimal totalAmount = BigDecimal.ZERO;
+        for (CartItem cartItem : cartItems) {
+            OrderItem orderItem = new OrderItem();
+            orderItem.setOrderId(orderId);
+            orderItem.setProductId(cartItem.getProductId());
+            orderItem.setQuantity(cartItem.getQuantity());
+
+            Optional<Product> product = productService.getProductById(cartItem.getProductId());
+            if (product.isEmpty()) {
+                throw new IllegalArgumentException("Invalid product ID");
+            }
+            BigDecimal price = product.get().getPrice();
+            BigDecimal itemTotal = price.multiply(BigDecimal.valueOf(cartItem.getQuantity()));
+            orderItem.setPrice(itemTotal);
+
+            totalAmount = totalAmount.add(itemTotal);
+            orderItemService.addOrderItem(orderItem);
+        }
+
+        // 更新订单总金额
+        order.setTotalAmount(totalAmount);
+        orderMapper.updateById(order);
+
+        return orderId;
+    }
+    /**
+     * 取消订单
+     * @param orderId 订单ID
+     * @return 是否成功
+     */
+    @Override
+    public boolean cancelOrder(String orderId, String userId) {
+        // 验证订单状态是否可以取消
+        Order order = getOrderById(orderId);
         if (order == null) {
             throw new RuntimeException("Order not found");
         }
-
-        // 检查订单状态（假设 "PENDING" 和 "PAID" 可取消）
-        /*
-        * 和数据库中订单表的状态保持一致
-        *
-        * */
-        if (!"pending".equals(order.getStatus()) && !"paid".equals(order.getStatus())) {
-            throw new RuntimeException("Order cannot be canceled");
+        if (!order.getUserId().equals(userId)) {
+            throw new IllegalArgumentException("Order does not belong to current user");
         }
-
-        // 更新订单状态为 "CANCELED"
+        if (!order.getStatus().equals("pending") && !order.getStatus().equals("paid")) {
+            throw new IllegalArgumentException("Order cannot be cancelled");
+        }
+        // 更改订单状态为已取消
         order.setStatus("canceled");
         order.setUpdatedAt(LocalDateTime.now());
-
-        // 保存修改
-        updateById(order);
+        // 提交
+        orderMapper.updateById(order);
+        return true;
     }
+
+    /**
+     * 获取订单项(卖家)
+     * @param userId 卖家ID
+     * @return 订单项列表
+     */
+    @Override
+    public getOrderResponse getOrderBySeller(String userId){
+        /* 卖家视角下的订单列表，由于数据库不完整，暂时无法实现
+        List <Order> orders = orderMapper.selectList(new LambdaQueryWrapper<Order>().eq(Order::getSellerId, userId));
+        if (orders.isEmpty()) {
+            return new null;
+        }
+        List<OrderDetailResponse> orderDetailResponses = new ArrayList<>();
+        for (Order order : orders) {
+            orderDetailResponses.add(OrderDetailGenerator(order));
+        }
+        return new getOrderResponse(orderDetailResponses);
+        */
+        return null;
+    }
+
+    // 生成订单详情，class内部使用
+    @Contract("_ -> new")
+    private @NotNull OrderDetailResponse OrderDetailGenerator(@NotNull Order order) {
+        List<OrderItemResponse> orderItemResponses = new ArrayList<>();
+        List<OrderItem> orderItems = orderItemService.getOrderItemByOrderId(order.getOrderId());
+        for (OrderItem orderItem : orderItems) {
+            Optional<Product> product = productService.getProductById(orderItem.getProductId());
+            if (product.isEmpty()) {
+                throw new IllegalArgumentException("Invalid product ID");
+            }
+            orderItemResponses.add(new OrderItemResponse(orderItem.getProductId(), product.get().getName(), orderItem.getQuantity(), orderItem.getPrice()));
+        }
+        return new OrderDetailResponse(order.getOrderId(), order.getStatus(), new getOrderItemResponse(orderItemResponses));
+    }
+
 }


### PR DESCRIPTION
按照apifox上接口的要求，实现了apifox上给出的三个接口的方法。

目前，由于数据库中order表没有sellerId，卖家查看order的方法无法执行，请尽快更新数据库的order表。

此外，有个疑问：为什么提交订单的api需要cartId？直接用从session转换到的userId来获取cartId岂不是更合理？难不成每个买家有多个cart？

另外，用户功能有bug，获取到的sessionid转换的userid无效（连用户登出都做不到），导致目前无法测试order部分的代码。
