### PR TITLE
Order application debug

### DIFF
--- a/src/main/java/cn/edu/xidian/tafei_mall/model/vo/OrderCreateVO.java
+++ b/src/main/java/cn/edu/xidian/tafei_mall/model/vo/OrderCreateVO.java
@@ -1,7 +1,9 @@
 package cn.edu.xidian.tafei_mall.model.vo;
 
 import lombok.Data;
+import lombok.Getter;
 
+@Getter
 @Data
 public class OrderCreateVO {
     private String shippingAddressId;

--- a/src/main/java/cn/edu/xidian/tafei_mall/model/vo/OrderUpdateVO.java
+++ b/src/main/java/cn/edu/xidian/tafei_mall/model/vo/OrderUpdateVO.java
@@ -1,12 +1,11 @@
 package cn.edu.xidian.tafei_mall.model.vo;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
+import lombok.Getter;
 
+@Getter
 @Data
 public class OrderUpdateVO {
-    @JsonProperty("action")
-    private String status;
-
+    private String action;
     private String trackingNumber;
 }

--- a/src/main/java/cn/edu/xidian/tafei_mall/model/vo/OrderUpdateVO.java
+++ b/src/main/java/cn/edu/xidian/tafei_mall/model/vo/OrderUpdateVO.java
@@ -1,12 +1,12 @@
 package cn.edu.xidian.tafei_mall.model.vo;
 
-import cn.hutool.core.annotation.Alias;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 @Data
 public class OrderUpdateVO {
+    @JsonProperty("action")
+    private String status;
 
-    @Alias("status")
-    private String action;
-    // private String trackingNumber;
+    private String trackingNumber;
 }

--- a/src/main/java/cn/edu/xidian/tafei_mall/service/impl/OrderServiceImpl.java
+++ b/src/main/java/cn/edu/xidian/tafei_mall/service/impl/OrderServiceImpl.java
@@ -1,5 +1,6 @@
 package cn.edu.xidian.tafei_mall.service.impl;
 
+import cn.edu.xidian.tafei_mall.mapper.AddressMapper;
 import cn.edu.xidian.tafei_mall.mapper.CartItemMapper;
 import cn.edu.xidian.tafei_mall.mapper.CartMapper;
 import cn.edu.xidian.tafei_mall.model.entity.*;
@@ -38,16 +39,20 @@ public class OrderServiceImpl extends ServiceImpl<OrderMapper, Order> implements
     private OrderItemService orderItemService;
     @Autowired
     private ProductService productService;
-    /* 由于Service层的Cart不完整，暂时用Mapper层的方法代替
+    /* 由于Service层的Cart和Address不完整，暂时用Mapper层的方法代替
     @Autowired
     private CartService cartService;
     @Autowired
     private CartItemService cartItemService;
+    @Autowired
+    private AddressService addressService;
      */
     @Autowired
     private CartMapper cartMapper;
     @Autowired
     private CartItemMapper cartItemMapper;
+    @Autowired
+    private AddressMapper addressMapper;
 
     /**
      * 获取订单(内部使用)
@@ -139,7 +144,24 @@ public class OrderServiceImpl extends ServiceImpl<OrderMapper, Order> implements
             orderItem.setPrice(product.get().getPrice().multiply(BigDecimal.valueOf(cartItem.getQuantity())));
             orderItemListMap.get(sellerId).add(orderItem);
         }
-
+        // 获取地址
+        String addressId;
+        if (orderCreateVO != null) {
+            Order tempOrder = BeanUtil.toBean(orderCreateVO, Order.class);
+            addressId = tempOrder.getShippingAddressId();
+            // Address address = addressService.getAddressById(addressId);
+            Address address = addressMapper.selectById(addressId);
+            if (address == null) {
+                throw new IllegalArgumentException("Invalid address ID");
+            }
+        } else {
+            // Address address = addressService.getAddressByUserId(userId).get(0);
+            Address address = addressMapper.selectList(new QueryWrapper<Address>().eq("user_id", userId)).get(0);
+            if (address == null) {
+                throw new IllegalArgumentException("Address not found");
+            }
+            addressId = address.getAddressId();
+        }
         // 生成每个seller的订单
         // Order tempOrder = BeanUtil.toBean(orderCreateVO, Order.class);
         List<String> orderIds = new ArrayList<>();
@@ -148,7 +170,7 @@ public class OrderServiceImpl extends ServiceImpl<OrderMapper, Order> implements
             Order order = new Order();
             order.setUserId(userId);
             // order.setSellerId(entry.getKey());
-            // order.setAddressId(tempOrder.getAddressId());
+            order.setShippingAddressId(addressId);
             order.setStatus("pending");
             order.setCreatedAt(LocalDateTime.now());
             order.setUpdatedAt(LocalDateTime.now());
@@ -231,7 +253,12 @@ public class OrderServiceImpl extends ServiceImpl<OrderMapper, Order> implements
                 // order.setTrackingNumber(tempOrder.getTrackingNumber());
                 order.setUpdatedAt(LocalDateTime.now());
                 orderMapper.updateById(order);
-                return new updateOrderResponse(order.getStatus());
+                if (Objects.equals(order.getStatus(), "shipping")) {
+                    return new updateOrderResponse("已发货");
+                } else {
+                    throw new RuntimeException("Failed to update order status");
+                }
+
             }
             case "cancel": { // to 'canceled'
                 if (!order.getStatus().equals("pending") && !order.getStatus().equals("paid")) {
@@ -240,7 +267,11 @@ public class OrderServiceImpl extends ServiceImpl<OrderMapper, Order> implements
                 order.setStatus("canceled");
                 order.setUpdatedAt(LocalDateTime.now());
                 orderMapper.updateById(order);
-                return new updateOrderResponse(order.getStatus());
+                if (Objects.equals(order.getStatus(), "canceled")) {
+                    return new updateOrderResponse("已取消");
+                } else {
+                    throw new RuntimeException("Failed to update order status");
+                }
             }
             default:
                 throw new IllegalArgumentException("Invalid status");

--- a/src/main/java/cn/edu/xidian/tafei_mall/service/impl/OrderServiceImpl.java
+++ b/src/main/java/cn/edu/xidian/tafei_mall/service/impl/OrderServiceImpl.java
@@ -151,7 +151,7 @@ public class OrderServiceImpl extends ServiceImpl<OrderMapper, Order> implements
             if (address == null) {
                 throw new IllegalArgumentException("Invalid address ID");
             }
-        } else {
+        } else { // 如果没有传入地址ID，使用用户默认地址(默认为第一个地址)
             // Address address = addressService.getAddressByUserId(userId).get(0);
             Address address = addressMapper.selectList(new QueryWrapper<Address>().eq("user_id", userId)).get(0);
             if (address == null) {

--- a/src/main/java/cn/edu/xidian/tafei_mall/service/impl/OrderServiceImpl.java
+++ b/src/main/java/cn/edu/xidian/tafei_mall/service/impl/OrderServiceImpl.java
@@ -8,10 +8,8 @@ import cn.edu.xidian.tafei_mall.mapper.OrderMapper;
 import cn.edu.xidian.tafei_mall.model.vo.OrderCreateVO;
 import cn.edu.xidian.tafei_mall.model.vo.OrderUpdateVO;
 import cn.edu.xidian.tafei_mall.model.vo.Response.Buyer.*;
-import cn.edu.xidian.tafei_mall.model.vo.Response.Seller.OrderItemResponse;
 import cn.edu.xidian.tafei_mall.model.vo.Response.Seller.updateOrderResponse;
 import cn.edu.xidian.tafei_mall.service.*;
-import cn.hutool.core.bean.BeanUtil;
 import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
 import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
 import org.jetbrains.annotations.Contract;
@@ -147,8 +145,7 @@ public class OrderServiceImpl extends ServiceImpl<OrderMapper, Order> implements
         // 获取地址
         String addressId;
         if (orderCreateVO != null) {
-            Order tempOrder = BeanUtil.toBean(orderCreateVO, Order.class);
-            addressId = tempOrder.getShippingAddressId();
+            addressId = orderCreateVO.getShippingAddressId();
             // Address address = addressService.getAddressById(addressId);
             Address address = addressMapper.selectById(addressId);
             if (address == null) {
@@ -243,14 +240,13 @@ public class OrderServiceImpl extends ServiceImpl<OrderMapper, Order> implements
             throw new IllegalArgumentException("Order does not belong to current user");
         }
         // 更新订单状态
-        Order tempOrder = BeanUtil.toBean(orderUpdateVO, Order.class);
-        switch (tempOrder.getStatus()) {
+        switch (orderUpdateVO.getAction()) {
             case "ship": { // to 'shipping'
                 if (!order.getStatus().equals("paid")) {
                     throw new IllegalArgumentException("Order cannot be shipping");
                 }
                 order.setStatus("shipping");
-                // order.setTrackingNumber(tempOrder.getTrackingNumber());
+                // order.setTrackingNumber(orderUpdateVO.getTrackingNumber());
                 order.setUpdatedAt(LocalDateTime.now());
                 orderMapper.updateById(order);
                 if (Objects.equals(order.getStatus(), "shipping")) {


### PR DESCRIPTION
debug：主键缺失，如cartId,shippingaddressId等，注意，这里的shippingaddressId默认使用第一个Id
修改：
关于主键缺失问题，已使用用户的第一个地址的id，此外，在order表和orderitem表中没有cartid，因此忽略cartid主键问题。

debug：卖方管理订单接口错误，请仔细查看接口文档
修改：
在OrderUpdateVO里，使用
private String action;
private String trackingNumber;
以确保接收参数正确。
目前由于数据库order表缺失tracking_number字段，在卖家管理的ship中已注释掉
order.setTrackingNumber(orderUpdateVO.getTrackingNumber());
此外，由于apifox卖家管理接口只给了ship和cancel，因此卖家视角的订单管理仅实现ship和cancel功能。

